### PR TITLE
Fix URL pattern matching when protocol is included

### DIFF
--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -158,7 +158,12 @@ export function urlMatchesPattern(url: string, pattern: string): boolean {
     const hostname = urlObj.hostname.toLowerCase();
     const pathname = urlObj.pathname.toLowerCase();
     const fullPath = hostname + pathname;
-    const normalizedPattern = pattern.toLowerCase().trim();
+    
+    // Normalize pattern: strip protocol if accidentally included
+    let normalizedPattern = pattern.toLowerCase().trim();
+    normalizedPattern = normalizedPattern
+      .replace(/^https?:\/\//, "")
+      .replace(/^www\./, "");
 
     // Handle path patterns (e.g., "x.com/messages")
     if (normalizedPattern.includes("/")) {


### PR DESCRIPTION
Fixes #1

Strips protocol (http://, https://) and www. prefix from URL patterns before matching, so patterns like `youtube.com/shorts` work correctly even if users accidentally include the full URL.