### PR TITLE
ci: add firefox extension build to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,18 +41,25 @@ jobs:
       - name: install dependencies
         run: bun install --frozen-lockfile
 
-      - name: build extension
+      - name: build chrome extension
         run: bun run build
 
-      - name: create zip artifact
+      - name: build firefox extension
+        run: bun run build:firefox
+
+      - name: create zip artifacts
         run: |
           cd .output/chrome-mv3
-          zip -r ../../distacted-chrome-mv3.zip .
+          zip -r ../../distacted-chrome.zip .
+          cd ../firefox-mv3
+          zip -r ../../distacted-firefox.zip .
 
       - name: create release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.event.inputs.tag || github.ref_name }}
-          files: distacted-chrome-mv3.zip
+          files: |
+            distacted-chrome.zip
+            distacted-firefox.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -9,8 +9,10 @@
     "dev:firefox": "wxt -b firefox",
     "build": "wxt build",
     "build:firefox": "wxt build -b firefox",
+    "build:all": "wxt build && wxt build -b firefox",
     "zip": "wxt zip",
     "zip:firefox": "wxt zip -b firefox",
+    "zip:all": "wxt zip && wxt zip -b firefox",
     "compile": "tsc --noEmit",
     "postinstall": "wxt prepare"
   },


### PR DESCRIPTION
Updated the release workflow to build and publish Firefox extension alongside Chrome. This adds Firefox build steps, creates separate zip artifacts for each browser, and includes convenience scripts for building both platforms.