### PR TITLE
config: Add Helium browser support

### DIFF
--- a/packages/extension/wxt.config.ts
+++ b/packages/extension/wxt.config.ts
@@ -1,11 +1,24 @@
 import { defineConfig } from "wxt";
 import tailwindcss from "@tailwindcss/vite";
 import path from "path";
+import fs from "fs/promises";
+const hasHelium = await fs
+  .access("/Applications/Helium.app")
+  .then(() => true)
+  .catch(() => false);
 
 // See https://wxt.dev/api/config.html
 export default defineConfig({
   modules: ["@wxt-dev/module-react"],
   srcDir: "src",
+  webExt: {
+    chromiumArgs: ["--user-data-dir=./.wxt/chrome-data"],
+    binaries: hasHelium
+      ? {
+          chrome: "/Applications/Helium.app/Contents/MacOS/Helium",
+        }
+      : undefined,
+  },
   manifest: ({ browser }) => {
     const isFirefox = browser === "firefox";
 


### PR DESCRIPTION
Adds automatic detection and configuration for Helium browser in WXT dev mode.

- Detects if Helium app is installed at /Applications/Helium.app
- Configures WXT to use Helium binary when available
- Falls back to default Chrome if Helium is not found