### PR TITLE
challenges(maths): prevent question skip on rapid Enter

### DIFF
--- a/packages/extension/src/components/challenges/maths.tsx
+++ b/packages/extension/src/components/challenges/maths.tsx
@@ -431,6 +431,7 @@ const MathsChallenge = memo(
     const [feedback, setFeedback] = useState<Record<number, "correct" | "incorrect" | null>>({});
     const [completed, setCompleted] = useState(false);
     const inputRef = useRef<HTMLInputElement>(null);
+    const isAdvancingRef = useRef(false);
 
     const currentQuestion = questions[currentQuestionIndex];
     const currentAnswer = answers[currentQuestionIndex] ?? null;
@@ -439,15 +440,17 @@ const MathsChallenge = memo(
     const instantSubmit = settings.instantSubmit ?? true;
 
     const advanceQuestion = useCallback(() => {
+      if (isAdvancingRef.current) return;
+      isAdvancingRef.current = true;
+
       if (currentQuestionIndex === questions.length - 1) {
-        // Last question answered correctly
         setCompleted(true);
         setTimeout(() => {
           onComplete();
         }, 500);
       } else {
-        // Move to next question after a brief delay
         setTimeout(() => {
+          isAdvancingRef.current = false;
           setCurrentQuestionIndex((prev) => prev + 1);
         }, 500);
       }


### PR DESCRIPTION
Fixes #27. Added `isAdvancingRef` guard in `advanceQuestion` to prevent question skipping when spamming Enter or using `instantSubmit` mode. The ref blocks re-entrant calls within the 500ms advance window and resets after the state update completes.

<a href="https://capy.ai/project/480c2640-72a8-49b6-a462-8f9af418b4b1/pull/29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/480c2640-72a8-49b6-a462-8f9af418b4b1/task/a71f18b9-c7b3-4f8c-adda-adf947572647"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.3-codex-fast&task=DIS-14&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.3-codex-fast&task=DIS-14"><img alt="DIS-14 · 5.3-Codex-Fast" src="https://capy.ai/api/badge/task.svg?model=gpt-5.3-codex-fast&task=DIS-14"></picture></a>