### PR TITLE
Add multi-agent hook support and revamp CLI TUI with clack/prompts

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "wxt-react-starter",
@@ -65,14 +66,14 @@
       "name": "@distracted/server",
       "version": "1.2.0",
       "bin": {
-        "distracted-server": "./dist/bin.js",
-        "server": "./dist/bin.js",
+        "server": "dist/bin.js",
       },
       "dependencies": {
+        "@clack/prompts": "^1.1.0",
         "@hono/node-server": "^1.19.7",
         "@hono/node-ws": "^1.2.0",
-        "cac": "^6.7.14",
         "hono": "^4.11.3",
+        "picocolors": "^1.1.1",
         "zod": "^4.3.5",
       },
       "devDependencies": {
@@ -166,6 +167,10 @@
     "@base-ui/react": ["@base-ui/react@1.0.0", "", { "dependencies": { "@babel/runtime": "^7.28.4", "@base-ui/utils": "0.2.3", "@floating-ui/react-dom": "^2.1.6", "@floating-ui/utils": "^0.2.10", "reselect": "^5.1.1", "tabbable": "^6.3.0", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@types/react": "^17 || ^18 || ^19", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-4USBWz++DUSLTuIYpbYkSgy1F9ZmNG9S/lXvlUN6qMK0P0RlW+6eQmDUB4DgZ7HVvtXl4pvi4z5J2fv6Z3+9hg=="],
 
     "@base-ui/utils": ["@base-ui/utils@0.2.3", "", { "dependencies": { "@babel/runtime": "^7.28.4", "@floating-ui/utils": "^0.2.10", "reselect": "^5.1.1", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@types/react": "^17 || ^18 || ^19", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-/CguQ2PDaOzeVOkllQR8nocJ0FFIDqsWIcURsVmm53QGo8NhFNpePjNlyPIB41luxfOqnG7PU0xicMEw3ls7XQ=="],
+
+    "@clack/core": ["@clack/core@1.1.0", "", { "dependencies": { "sisteransi": "^1.0.5" } }, "sha512-SVcm4Dqm2ukn64/8Gub2wnlA5nS2iWJyCkdNHcvNHPIeBTGojpdJ+9cZKwLfmqy7irD4N5qLteSilJlE0WLAtA=="],
+
+    "@clack/prompts": ["@clack/prompts@1.1.0", "", { "dependencies": { "@clack/core": "1.1.0", "sisteransi": "^1.0.5" } }, "sha512-pkqbPGtohJAvm4Dphs2M8xE29ggupihHdy1x84HNojZuMtFsHiUlRvqD24tM2+XmI+61LlfNceM3Wr7U5QES5g=="],
 
     "@devicefarmer/adbkit": ["@devicefarmer/adbkit@3.3.8", "", { "dependencies": { "@devicefarmer/adbkit-logcat": "^2.1.2", "@devicefarmer/adbkit-monkey": "~1.2.1", "bluebird": "~3.7", "commander": "^9.1.0", "debug": "~4.3.1", "node-forge": "^1.3.1", "split": "~1.0.1" }, "bin": { "adbkit": "bin/adbkit" } }, "sha512-7rBLLzWQnBwutH2WZ0EWUkQdihqrnLYCUMaB44hSol9e0/cdIhuNFcqZO0xNheAU6qqHVA8sMiLofkYTgb+lmw=="],
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -30,10 +30,11 @@
     "check": "bun run lint:fix && bun run format && bun run knip"
   },
   "dependencies": {
+    "@clack/prompts": "^1.1.0",
     "@hono/node-server": "^1.19.7",
     "@hono/node-ws": "^1.2.0",
-    "cac": "^6.7.14",
     "hono": "^4.11.3",
+    "picocolors": "^1.1.1",
     "zod": "^4.3.5"
   },
   "devDependencies": {

--- a/packages/server/src/bin.ts
+++ b/packages/server/src/bin.ts
@@ -78,7 +78,13 @@ async function main(): Promise<void> {
     return;
   }
 
+  const hasPort = getFlag("port");
   const portValue = getFlagValue("port");
+  if (hasPort && portValue === undefined) {
+    UI.error("--port requires a value.");
+    process.exit(1);
+  }
+
   const port = Number(portValue ?? DEFAULT_PORT);
   if (!Number.isFinite(port) || port <= 0 || port >= 65536) {
     UI.error("Invalid port number.");
@@ -116,13 +122,16 @@ async function main(): Promise<void> {
 
     p.intro(pc.bgCyan(pc.black(" distracted ")));
     if (!agents) {
-      await interactiveSetup(port);
+      const didSetup = await interactiveSetup(port);
+      if (didSetup) {
+        p.outro("Done! Run 'bunx @distracted/server' to start.");
+      }
     } else {
       for (const agent of agents) {
         await setupAgent(agent, port);
       }
+      p.outro("Done! Run 'bunx @distracted/server' to start.");
     }
-    p.outro("Done! Run 'bunx @distracted/server' to start.");
     return;
   }
 
@@ -135,13 +144,16 @@ async function main(): Promise<void> {
 
     p.intro(pc.bgCyan(pc.black(" distracted ")));
     if (!agents) {
-      await interactiveRemove();
+      const didRemove = await interactiveRemove();
+      if (didRemove) {
+        p.outro("Hook cleanup complete.");
+      }
     } else {
       for (const agent of agents) {
         await removeAgent(agent);
       }
+      p.outro("Hook cleanup complete.");
     }
-    p.outro("Hook cleanup complete.");
     return;
   }
 
@@ -166,8 +178,10 @@ async function main(): Promise<void> {
 
       if (shouldSetup) {
         p.intro(pc.bgCyan(pc.black(" distracted ")));
-        await interactiveSetup(port);
-        p.outro("Setup complete.");
+        const didSetup = await interactiveSetup(port);
+        if (didSetup) {
+          p.outro("Setup complete.");
+        }
       } else {
         p.log.info("Skipping setup. You can run 'bunx @distracted/server --setup' later.");
       }

--- a/packages/server/src/bin.ts
+++ b/packages/server/src/bin.ts
@@ -1,178 +1,175 @@
-import { cac } from "cac";
+import * as p from "@clack/prompts";
+import pc from "picocolors";
+
 import { UI } from "@/lib/ui";
-import { DEFAULT_PORT } from "./types";
+import { startServer } from "./server";
 import {
   getSetupStatus,
   interactiveRemove,
   interactiveSetup,
   removeAgent,
   setupAgent,
+  type AgentType,
 } from "./setup/index";
-import { startServer } from "./server";
+import { DEFAULT_PORT } from "./types";
 
-type AgentType = Parameters<typeof setupAgent>[0];
+const ALL_AGENTS: AgentType[] = ["claude", "opencode", "gemini", "cursor", "cline"];
 
-function parseAgentSelection(input: unknown): AgentType[] | null {
-  if (input === true || input === undefined) return null;
-  if (typeof input !== "string") return null;
+const args = process.argv.slice(2);
+
+function getFlag(name: string): boolean {
+  return args.includes(`--${name}`) || args.some((arg) => arg.startsWith(`--${name}=`));
+}
+
+function getFlagValue(name: string): string | undefined {
+  const equalsArg = args.find((arg) => arg.startsWith(`--${name}=`));
+  if (equalsArg) {
+    const value = equalsArg.slice(`--${name}=`.length);
+    return value.length > 0 ? value : undefined;
+  }
+
+  const idx = args.indexOf(`--${name}`);
+  if (idx < 0) return undefined;
+  const value = args[idx + 1];
+  if (!value || value.startsWith("--")) return undefined;
+  return value;
+}
+
+function showHelp(): void {
+  p.log.info("Usage: bunx @distracted/server [options]");
+  p.log.info("  --setup [agent]   Configure hooks (claude, opencode, gemini, cursor, cline, all)");
+  p.log.info("  --remove [agent]  Remove hooks (claude, opencode, gemini, cursor, cline, all)");
+  p.log.info("  --status          Show configured hook status");
+  p.log.info(`  --port <port>     Server port (default: ${DEFAULT_PORT})`);
+  p.log.info("  --help            Show help");
+}
+
+function parseAgentSelection(input: string | undefined): AgentType[] | null {
+  if (!input) return null;
 
   const normalized = input.trim().toLowerCase();
-  if (normalized === "all") return ["claude", "opencode"];
-  if (normalized === "claude") return ["claude"];
-  if (normalized === "opencode") return ["opencode"];
-  return [];
+  if (normalized === "all") {
+    return [...ALL_AGENTS];
+  }
+
+  const parts = normalized
+    .split(",")
+    .map((part) => part.trim())
+    .filter(Boolean);
+
+  if (parts.length === 0) return [];
+
+  const values = new Set<AgentType>();
+  for (const part of parts) {
+    if (ALL_AGENTS.includes(part as AgentType)) {
+      values.add(part as AgentType);
+    } else {
+      return [];
+    }
+  }
+
+  return [...values];
 }
 
 async function main(): Promise<void> {
-  const cli = cac("distracted-server");
-  cli
-    .option("--setup [agent]", "Configure AI coding agent hooks (claude, opencode, all)")
-    .option("--remove [agent]", "Remove AI coding agent hooks (claude, opencode, all)")
-    .option("--status", "Show which agents are configured")
-    .option("--port <port>", `Server port (default: ${DEFAULT_PORT})`, {
-      default: DEFAULT_PORT,
-    })
-    .help();
-
-  const parsed = cli.parse();
-  const options = parsed.options as {
-    setup?: unknown;
-    remove?: unknown;
-    status?: boolean;
-    port: unknown;
-    help?: boolean;
-  };
-
-  if (options.help) {
-    process.exit(0);
+  const hasHelp = getFlag("help") || args.includes("-h");
+  if (hasHelp) {
+    showHelp();
+    return;
   }
 
-  const port = Number(options.port);
+  const portValue = getFlagValue("port");
+  const port = Number(portValue ?? DEFAULT_PORT);
   if (!Number.isFinite(port) || port <= 0 || port >= 65536) {
-    UI.error("Invalid port number");
+    UI.error("Invalid port number.");
     process.exit(1);
   }
 
-  const hasSetup = options.setup !== undefined;
-  const hasRemove = options.remove !== undefined;
-  const hasStatus = options.status === true;
+  const hasSetup = getFlag("setup");
+  const hasRemove = getFlag("remove");
+  const hasStatus = getFlag("status");
 
   const modeCount = [hasSetup, hasRemove, hasStatus].filter(Boolean).length;
   if (modeCount > 1) {
-    UI.error("Use only one of --setup, --remove, or --status");
+    UI.error("Use only one of --setup, --remove, or --status.");
     process.exit(1);
   }
 
   if (hasStatus) {
     const status = await getSetupStatus();
-    UI.println(UI.Style.TEXT_SUCCESS_BOLD + "Setup status" + UI.Style.TEXT_NORMAL);
-    UI.println(
-      UI.Style.TEXT_DIM +
-        `Claude Code: ${status.claude ? "configured" : "not configured"}` +
-        UI.Style.TEXT_NORMAL,
-    );
-    UI.println(
-      UI.Style.TEXT_DIM +
-        `OpenCode:    ${status.opencode ? "configured" : "not configured"}` +
-        UI.Style.TEXT_NORMAL,
-    );
-    UI.empty();
-    process.exit(0);
+    p.log.info(pc.bold("Setup status"));
+
+    for (const agent of ALL_AGENTS) {
+      p.log.info(
+        `${agent.padEnd(8)} ${status[agent] ? pc.green("configured") : pc.yellow("not configured")}`,
+      );
+    }
+    return;
   }
 
   if (hasSetup) {
-    const agents = parseAgentSelection(options.setup);
+    const agents = parseAgentSelection(getFlagValue("setup"));
     if (agents && agents.length === 0) {
-      UI.error("Invalid agent. Use: claude, opencode, all");
+      UI.error("Invalid agent. Use: claude, opencode, gemini, cursor, cline, all.");
       process.exit(1);
     }
 
+    p.intro(pc.bgCyan(pc.black(" distracted ")));
     if (!agents) {
-      try {
-        await interactiveSetup(port);
-      } catch (err) {
-        if (err instanceof Error && err.name === "UICancelledError") {
-          UI.empty();
-          UI.println(UI.Style.TEXT_DIM + "Cancelled." + UI.Style.TEXT_NORMAL);
-          UI.empty();
-        } else {
-          throw err;
-        }
+      await interactiveSetup(port);
+    } else {
+      for (const agent of agents) {
+        await setupAgent(agent, port);
       }
-      process.exit(0);
     }
-
-    for (const agent of agents) {
-      await setupAgent(agent, port);
-    }
-
-    process.exit(0);
+    p.outro("Done! Run 'bunx @distracted/server' to start.");
+    return;
   }
 
   if (hasRemove) {
-    const agents = parseAgentSelection(options.remove);
+    const agents = parseAgentSelection(getFlagValue("remove"));
     if (agents && agents.length === 0) {
-      UI.error("Invalid agent. Use: claude, opencode, all");
+      UI.error("Invalid agent. Use: claude, opencode, gemini, cursor, cline, all.");
       process.exit(1);
     }
 
+    p.intro(pc.bgCyan(pc.black(" distracted ")));
     if (!agents) {
-      try {
-        await interactiveRemove();
-      } catch (err) {
-        if (err instanceof Error && err.name === "UICancelledError") {
-          UI.empty();
-          UI.println(UI.Style.TEXT_DIM + "Cancelled." + UI.Style.TEXT_NORMAL);
-          UI.empty();
-        } else {
-          throw err;
-        }
+      await interactiveRemove();
+    } else {
+      for (const agent of agents) {
+        await removeAgent(agent);
       }
-      process.exit(0);
     }
-
-    for (const agent of agents) {
-      await removeAgent(agent);
-    }
-
-    process.exit(0);
+    p.outro("Hook cleanup complete.");
+    return;
   }
 
   const status = await getSetupStatus();
-  if (!status.claude && !status.opencode) {
-    UI.println(
-      UI.Style.TEXT_WARNING_BOLD + "No AI agent hooks are configured yet." + UI.Style.TEXT_NORMAL,
-    );
-    UI.empty();
+  const hasConfiguredAgent = ALL_AGENTS.some((agent) => status[agent]);
+
+  if (!hasConfiguredAgent) {
+    p.log.warn("No AI agent hooks configured.");
 
     if (!process.stdin.isTTY) {
-      UI.println(
-        UI.Style.TEXT_DIM +
-          "Non-interactive shell detected; skipping setup prompt." +
-          UI.Style.TEXT_NORMAL,
-      );
-      UI.println("Run 'bunx @distracted/server --setup' to configure hooks.");
-      UI.empty();
+      p.log.info(pc.dim("Non-interactive shell detected; skipping setup prompt."));
+      p.log.info("Run 'bunx @distracted/server --setup' to configure hooks.");
     } else {
-      const answer = await UI.input("Would you like to set them up now? (Y/n) ");
-      const normalized = answer.trim().toLowerCase();
-      if (normalized === "" || normalized === "y" || normalized === "yes") {
-        try {
-          await interactiveSetup(port);
-        } catch (err) {
-          if (err instanceof Error && err.name === "UICancelledError") {
-            UI.empty();
-            UI.println(UI.Style.TEXT_DIM + "Cancelled." + UI.Style.TEXT_NORMAL);
-            UI.empty();
-          } else {
-            throw err;
-          }
-        }
-        UI.empty();
+      const shouldSetup = await p.confirm({
+        message: "No AI agent hooks configured. Set them up now?",
+      });
+
+      if (p.isCancel(shouldSetup)) {
+        p.cancel("Cancelled.");
+        process.exit(0);
+      }
+
+      if (shouldSetup) {
+        p.intro(pc.bgCyan(pc.black(" distracted ")));
+        await interactiveSetup(port);
+        p.outro("Setup complete.");
       } else {
-        UI.empty();
-        UI.println("Skipping setup. You can run 'bunx @distracted/server --setup' later.");
-        UI.empty();
+        p.log.info("Skipping setup. You can run 'bunx @distracted/server --setup' later.");
       }
     }
   }

--- a/packages/server/src/lib/ui.ts
+++ b/packages/server/src/lib/ui.ts
@@ -1,5 +1,6 @@
 import { EOL } from "node:os";
-import { createInterface } from "node:readline";
+
+import pc from "picocolors";
 import z from "zod/v4";
 
 import { NamedError } from "@/lib/error";
@@ -7,26 +8,11 @@ import { NamedError } from "@/lib/error";
 export namespace UI {
   export const CancelledError = NamedError.create("UICancelledError", z.void());
 
-  export const Style = {
-    TEXT_HIGHLIGHT: "\x1b[96m",
-    TEXT_HIGHLIGHT_BOLD: "\x1b[96m\x1b[1m",
-    TEXT_DIM: "\x1b[90m",
-    TEXT_DIM_BOLD: "\x1b[90m\x1b[1m",
-    TEXT_NORMAL: "\x1b[0m",
-    TEXT_NORMAL_BOLD: "\x1b[1m",
-    TEXT_WARNING: "\x1b[93m",
-    TEXT_WARNING_BOLD: "\x1b[93m\x1b[1m",
-    TEXT_DANGER: "\x1b[91m",
-    TEXT_DANGER_BOLD: "\x1b[91m\x1b[1m",
-    TEXT_SUCCESS: "\x1b[92m",
-    TEXT_SUCCESS_BOLD: "\x1b[92m\x1b[1m",
-    TEXT_INFO: "\x1b[94m",
-    TEXT_INFO_BOLD: "\x1b[94m\x1b[1m",
-  };
+  let blank = false;
 
   export function println(...message: string[]) {
-    print(...message);
-    process.stderr.write(EOL);
+    blank = false;
+    process.stderr.write(message.join(" ") + EOL);
   }
 
   export function print(...message: string[]) {
@@ -34,25 +20,14 @@ export namespace UI {
     process.stderr.write(message.join(" "));
   }
 
-  let blank = false;
   export function empty() {
     if (blank) return;
-    println("" + Style.TEXT_NORMAL);
+    println("");
     blank = true;
   }
 
-  export async function input(prompt: string): Promise<string> {
-    const rl = createInterface({ input: process.stdin, output: process.stdout });
-    return new Promise((resolve) => {
-      rl.question(prompt, (answer: string) => {
-        rl.close();
-        resolve(answer.trim());
-      });
-    });
-  }
-
   export function error(message: string) {
-    println(Style.TEXT_DANGER_BOLD + "Error: " + Style.TEXT_NORMAL + message);
+    println(`${pc.red(pc.bold("Error:"))} ${message}`);
   }
 
   export function markdown(text: string): string {

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1,14 +1,15 @@
-import { Hono } from "hono";
-import { cors } from "hono/cors";
+import * as p from "@clack/prompts";
 import { serve } from "@hono/node-server";
 import { createNodeWebSocket } from "@hono/node-ws";
-import { UI } from "@/lib/ui";
+import pc from "picocolors";
+import { Hono } from "hono";
+import { cors } from "hono/cors";
+
 import type { ClientMessage, HookPayload } from "./types";
 import { DEFAULT_PORT } from "./types";
 import { state } from "./state";
 
 const app = new Hono();
-
 const nodeWs = createNodeWebSocket({ app });
 
 app.use("*", cors());
@@ -16,10 +17,10 @@ app.use("*", cors());
 app.get(
   "/ws",
   nodeWs.upgradeWebSocket(() => {
-    let unsubscribe: (() => void) | undefined = undefined;
+    let unsubscribe: (() => void) | undefined;
 
     return {
-      onOpen(evt, ws) {
+      onOpen(_evt, ws) {
         unsubscribe = state.subscribe((message) => {
           ws.send(JSON.stringify(message));
         });
@@ -34,17 +35,17 @@ app.get(
           if (message.type === "ping") {
             ws.send(JSON.stringify({ type: "pong" }));
           }
-        } catch {
-          // ignore invalid messages
-        }
+        } catch {}
       },
       onClose: () => {
-        UI.println(UI.Style.TEXT_DIM + "Extension disconnected" + UI.Style.TEXT_NORMAL);
+        p.log.info(pc.dim("Extension disconnected"));
         unsubscribe?.();
       },
       onError: (event) => {
-        UI.println(UI.Style.TEXT_DANGER_BOLD + "WebSocket error" + UI.Style.TEXT_NORMAL);
-        UI.println(event instanceof Error ? (event.stack ?? event.message) : JSON.stringify(event));
+        p.log.error("WebSocket error");
+        p.log.error(
+          event instanceof Error ? (event.stack ?? event.message) : JSON.stringify(event),
+        );
         unsubscribe?.();
       },
     };
@@ -78,6 +79,7 @@ app.post("/hook", async (c) => {
       "SessionStart",
       "SessionEnd",
     ];
+
     if (!allowedEvents.includes(data.hook_event_name as HookPayload["hook_event_name"])) {
       return c.json({ error: "Invalid payload" }, 400);
     }
@@ -92,10 +94,11 @@ app.post("/hook", async (c) => {
           : undefined,
       cwd: typeof data.cwd === "string" ? data.cwd : undefined,
       transcript_path: typeof data.transcript_path === "string" ? data.transcript_path : undefined,
-      source:
-        data.source === "claude" || data.source === "opencode"
-          ? (data.source as HookPayload["source"])
-          : undefined,
+      source: ["claude", "opencode", "gemini", "cursor", "cline", "pi"].includes(
+        data.source as string,
+      )
+        ? (data.source as HookPayload["source"])
+        : undefined,
     };
 
     state.handleHook(payload);
@@ -116,23 +119,20 @@ export function startServer(port: number = DEFAULT_PORT): void {
       port,
     },
     (info) => {
-      UI.println(UI.Style.TEXT_SUCCESS_BOLD + "Distracted Server" + UI.Style.TEXT_NORMAL);
-      UI.println(
-        UI.Style.TEXT_INFO + `HTTP:      http://localhost:${info.port}` + UI.Style.TEXT_NORMAL,
+      p.note(
+        `HTTP:      ${pc.cyan(`http://localhost:${info.port}`)}\nWebSocket: ${pc.cyan(
+          `ws://localhost:${info.port}/ws`,
+        )}`,
+        pc.bold("Distracted Server"),
       );
-      UI.println(
-        UI.Style.TEXT_INFO + `WebSocket: ws://localhost:${info.port}/ws` + UI.Style.TEXT_NORMAL,
-      );
-      UI.println(UI.Style.TEXT_DIM + "Waiting for AI agent hooks..." + UI.Style.TEXT_NORMAL);
-      UI.empty();
+      p.log.info(pc.dim("Waiting for AI agent hooks..."));
     },
   );
 
   nodeWs.injectWebSocket(server);
 
   process.once("SIGINT", () => {
-    UI.empty();
-    UI.println(UI.Style.TEXT_DIM + "Shutting down..." + UI.Style.TEXT_NORMAL);
+    p.log.info(pc.dim("Shutting down..."));
     try {
       state.destroy();
       server.close();

--- a/packages/server/src/setup/claude.ts
+++ b/packages/server/src/setup/claude.ts
@@ -1,9 +1,11 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
+
+import * as p from "@clack/prompts";
+import pc from "picocolors";
 import { z } from "zod";
 
-import { UI } from "@/lib/ui";
 import { DEFAULT_PORT } from "../types";
 
 const ClaudeSettingsSchema = z
@@ -74,35 +76,32 @@ export async function setupClaude(port: number = DEFAULT_PORT): Promise<void> {
 
   await writeFile(settingsPath, JSON.stringify(settings, null, 2));
 
-  UI.println(UI.Style.TEXT_SUCCESS_BOLD + "Claude Code hooks configured." + UI.Style.TEXT_NORMAL);
-  UI.println(UI.Style.TEXT_DIM + `Path: ${settingsPath}` + UI.Style.TEXT_NORMAL);
-  UI.println(UI.Style.TEXT_DIM + `Port: ${port}` + UI.Style.TEXT_NORMAL);
-  UI.println(UI.Style.TEXT_DIM + "Next: Run 'bunx @distracted/server'" + UI.Style.TEXT_NORMAL);
-  UI.empty();
+  p.log.success("Claude Code hooks configured.");
+  p.log.info(`Path: ${pc.dim(settingsPath)}`);
+  p.log.info(`Port: ${pc.dim(String(port))}`);
+  p.log.info(`Next: ${pc.dim("Run 'bunx @distracted/server'")}`);
 }
 
 export async function isClaudeConfigured(): Promise<boolean> {
   const settingsPath = join(homedir(), ".claude", "settings.json");
   const settings = await readClaudeSettings(settingsPath);
-  if (!settings) return false;
-  if (!settings.hooks) return false;
+  if (!settings || !settings.hooks) return false;
 
-  const hooks = settings.hooks;
   const keys = Object.keys(makeHooksConfig(DEFAULT_PORT));
-  return keys.some((hookName) => hookName in hooks);
+  return keys.some((hookName) => hookName in settings.hooks!);
 }
 
 export async function removeClaude(): Promise<void> {
   const settingsPath = join(homedir(), ".claude", "settings.json");
   const settings = await readClaudeSettings(settingsPath);
+
   if (!settings) {
-    UI.println(
-      UI.Style.TEXT_DIM + "No settings.json found, nothing to remove." + UI.Style.TEXT_NORMAL,
-    );
+    p.log.info("No settings.json found, nothing to remove.");
     return;
   }
+
   if (!settings.hooks) {
-    UI.println(UI.Style.TEXT_DIM + "No hooks found in settings.json" + UI.Style.TEXT_NORMAL);
+    p.log.info("No hooks found in settings.json.");
     return;
   }
 
@@ -115,7 +114,6 @@ export async function removeClaude(): Promise<void> {
   }
 
   await writeFile(settingsPath, JSON.stringify(settings, null, 2));
-  UI.println(UI.Style.TEXT_SUCCESS_BOLD + "Claude Code hooks removed." + UI.Style.TEXT_NORMAL);
-  UI.println(UI.Style.TEXT_DIM + `Path: ${settingsPath}` + UI.Style.TEXT_NORMAL);
-  UI.empty();
+  p.log.success("Claude Code hooks removed.");
+  p.log.info(`Path: ${pc.dim(settingsPath)}`);
 }

--- a/packages/server/src/setup/cline.ts
+++ b/packages/server/src/setup/cline.ts
@@ -1,0 +1,145 @@
+import { mkdir, readFile, stat, unlink, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import * as p from "@clack/prompts";
+import pc from "picocolors";
+
+import { DEFAULT_PORT } from "../types";
+
+const CLINE_HOOKS_DIR = join(homedir(), "Documents", "Cline", "Rules", "Hooks");
+const MARKER = "// @distracted/server hook";
+
+const SCRIPT_EVENT_MAP = {
+  PreToolUse: ["PreToolUse"],
+  UserPromptSubmit: ["UserPromptSubmit"],
+  TaskStart: ["SessionStart"],
+  TaskComplete: ["Stop", "SessionEnd"],
+} as const;
+
+type ScriptName = keyof typeof SCRIPT_EVENT_MAP;
+
+function makeScript(port: number, events: readonly string[]): string {
+  return `#!/usr/bin/env node
+${MARKER}
+let inputData = "";
+process.stdin.on("data", (chunk) => {
+  inputData += chunk;
+});
+process.stdin.on("end", async () => {
+  try {
+    const input = inputData.trim() ? JSON.parse(inputData) : {};
+    const sessionId =
+      typeof input.taskId === "string" && input.taskId.length > 0
+        ? input.taskId
+        : \`cline-\${Date.now()}\`;
+    const workspaceRoots = Array.isArray(input.workspaceRoots) ? input.workspaceRoots : [];
+    const cwd = typeof workspaceRoots[0] === "string" ? workspaceRoots[0] : undefined;
+    const toolName =
+      typeof input.tool_name === "string"
+        ? input.tool_name
+        : typeof input.toolName === "string"
+          ? input.toolName
+          : typeof input.tool === "string"
+            ? input.tool
+            : undefined;
+    const toolInput =
+      input.tool_input && typeof input.tool_input === "object"
+        ? input.tool_input
+        : input.toolInput && typeof input.toolInput === "object"
+          ? input.toolInput
+          : undefined;
+
+    const requests = [];
+    for (const eventName of ${JSON.stringify(events)}) {
+      const payload = {
+        session_id: sessionId,
+        hook_event_name: eventName,
+        tool_name: toolName,
+        tool_input: toolInput,
+        cwd,
+        source: "cline",
+      };
+
+      requests.push(
+        fetch("http://localhost:${port}/hook", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        }),
+      );
+    }
+
+    await Promise.allSettled(requests);
+  } catch {
+  }
+
+  process.stdout.write("{}\\n");
+});
+`;
+}
+
+async function hasMarker(path: string): Promise<boolean> {
+  try {
+    const content = await readFile(path, "utf-8");
+    return content.includes(MARKER);
+  } catch {
+    return false;
+  }
+}
+
+export async function setupCline(port: number = DEFAULT_PORT): Promise<void> {
+  await mkdir(CLINE_HOOKS_DIR, { recursive: true });
+
+  const scriptNames = Object.keys(SCRIPT_EVENT_MAP) as ScriptName[];
+  for (const scriptName of scriptNames) {
+    const filePath = join(CLINE_HOOKS_DIR, scriptName);
+    await writeFile(filePath, makeScript(port, SCRIPT_EVENT_MAP[scriptName]), { mode: 0o755 });
+  }
+
+  p.log.success("Cline hooks configured.");
+  p.log.info(`Path: ${pc.dim(CLINE_HOOKS_DIR)}`);
+  p.log.info(`Port: ${pc.dim(String(port))}`);
+}
+
+export async function isClineConfigured(): Promise<boolean> {
+  const scriptNames = Object.keys(SCRIPT_EVENT_MAP) as ScriptName[];
+
+  for (const scriptName of scriptNames) {
+    const filePath = join(CLINE_HOOKS_DIR, scriptName);
+    try {
+      await stat(filePath);
+    } catch {
+      return false;
+    }
+
+    if (!(await hasMarker(filePath))) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+export async function removeCline(): Promise<void> {
+  const scriptNames = Object.keys(SCRIPT_EVENT_MAP) as ScriptName[];
+  let removed = 0;
+
+  for (const scriptName of scriptNames) {
+    const filePath = join(CLINE_HOOKS_DIR, scriptName);
+    if (!(await hasMarker(filePath))) {
+      continue;
+    }
+
+    await unlink(filePath);
+    removed += 1;
+  }
+
+  if (removed === 0) {
+    p.log.info("No distracted-managed Cline hooks found, nothing to remove.");
+    return;
+  }
+
+  p.log.success("Cline hooks removed.");
+  p.log.info(`Path: ${pc.dim(CLINE_HOOKS_DIR)}`);
+}

--- a/packages/server/src/setup/cursor.ts
+++ b/packages/server/src/setup/cursor.ts
@@ -1,0 +1,143 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import * as p from "@clack/prompts";
+import pc from "picocolors";
+import { z } from "zod";
+
+import { DEFAULT_PORT } from "../types";
+
+const CURSOR_DIR = join(homedir(), ".cursor");
+const CURSOR_HOOKS_PATH = join(CURSOR_DIR, "hooks.json");
+
+const CursorHookSchema = z
+  .object({
+    event: z.string().optional(),
+    command: z.string().optional(),
+    matcher: z.string().optional(),
+  })
+  .catchall(z.unknown());
+
+const CursorHooksFileSchema = z
+  .object({
+    hooks: z
+      .object({
+        agent: z
+          .object({
+            preToolUse: z.array(CursorHookSchema).optional(),
+            postToolUse: z.array(CursorHookSchema).optional(),
+            stop: z.array(CursorHookSchema).optional(),
+            sessionStart: z.array(CursorHookSchema).optional(),
+          })
+          .partial()
+          .optional(),
+      })
+      .partial()
+      .optional(),
+  })
+  .catchall(z.unknown());
+
+function makeHookCommand(port: number, hookEventName: string): string {
+  const TRANSFORM_COMMAND =
+    `node -e 'let d="";process.stdin.on("data",(c)=>d+=c);process.stdin.on("end",()=>{` +
+    `try{const j=JSON.parse(d||"{}");j.hook_event_name="${hookEventName}";j.source="cursor";process.stdout.write(JSON.stringify(j));}` +
+    `catch{process.stdout.write("{}");}});'`;
+  return `${TRANSFORM_COMMAND} | curl -s -X POST http://localhost:${port}/hook -H 'Content-Type: application/json' -d "$(cat)" > /dev/null 2>&1 &`;
+}
+
+function makeHooksConfig(
+  port: number,
+): NonNullable<NonNullable<z.infer<typeof CursorHooksFileSchema>["hooks"]>["agent"]> {
+  return {
+    sessionStart: [
+      {
+        event: "sessionStart",
+        command: makeHookCommand(port, "SessionStart"),
+      },
+    ],
+    preToolUse: [
+      {
+        event: "preToolUse",
+        command: makeHookCommand(port, "PreToolUse"),
+        matcher: "*",
+      },
+    ],
+    stop: [
+      {
+        event: "stop",
+        command: makeHookCommand(port, "Stop"),
+      },
+    ],
+  };
+}
+
+async function readCursorHooks(
+  path: string,
+): Promise<z.infer<typeof CursorHooksFileSchema> | null> {
+  try {
+    const content = await readFile(path, "utf-8");
+    const raw = JSON.parse(content) as unknown;
+    const parsed = CursorHooksFileSchema.safeParse(raw);
+    if (!parsed.success) return null;
+    return parsed.data as z.infer<typeof CursorHooksFileSchema>;
+  } catch {
+    return null;
+  }
+}
+
+export async function setupCursor(port: number = DEFAULT_PORT): Promise<void> {
+  await mkdir(CURSOR_DIR, { recursive: true });
+
+  const config = (await readCursorHooks(CURSOR_HOOKS_PATH)) ?? {};
+  const hooksConfig = makeHooksConfig(port);
+
+  config.hooks = config.hooks ?? {};
+  config.hooks.agent = {
+    ...config.hooks.agent,
+    ...hooksConfig,
+  };
+
+  await writeFile(CURSOR_HOOKS_PATH, JSON.stringify(config, null, 2));
+
+  p.log.success("Cursor hooks configured.");
+  p.log.info(`Path: ${pc.dim(CURSOR_HOOKS_PATH)}`);
+  p.log.info(`Port: ${pc.dim(String(port))}`);
+}
+
+export async function isCursorConfigured(): Promise<boolean> {
+  const config = await readCursorHooks(CURSOR_HOOKS_PATH);
+  const agentHooks = config?.hooks?.agent;
+  if (!agentHooks) return false;
+
+  return Boolean(agentHooks.sessionStart || agentHooks.preToolUse || agentHooks.stop);
+}
+
+export async function removeCursor(): Promise<void> {
+  const config = await readCursorHooks(CURSOR_HOOKS_PATH);
+  if (!config) {
+    p.log.info("No Cursor hooks.json found, nothing to remove.");
+    return;
+  }
+
+  if (!config.hooks?.agent) {
+    p.log.info("No Cursor agent hooks found.");
+    return;
+  }
+
+  delete config.hooks.agent.sessionStart;
+  delete config.hooks.agent.preToolUse;
+  delete config.hooks.agent.stop;
+
+  if (Object.keys(config.hooks.agent).length === 0) {
+    delete config.hooks.agent;
+  }
+
+  if (config.hooks && Object.keys(config.hooks).length === 0) {
+    delete config.hooks;
+  }
+
+  await writeFile(CURSOR_HOOKS_PATH, JSON.stringify(config, null, 2));
+  p.log.success("Cursor hooks removed.");
+  p.log.info(`Path: ${pc.dim(CURSOR_HOOKS_PATH)}`);
+}

--- a/packages/server/src/setup/gemini.ts
+++ b/packages/server/src/setup/gemini.ts
@@ -1,0 +1,123 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import * as p from "@clack/prompts";
+import pc from "picocolors";
+import { z } from "zod";
+
+import { DEFAULT_PORT } from "../types";
+
+const GEMINI_DIR = join(homedir(), ".gemini");
+const GEMINI_SETTINGS_PATH = join(GEMINI_DIR, "settings.json");
+
+const GeminiSettingsSchema = z
+  .object({
+    hooks: z.record(z.string(), z.array(z.unknown())).optional(),
+  })
+  .catchall(z.unknown());
+
+function makeHookCommand(port: number, hookEventName: string): string {
+  const TRANSFORM_COMMAND =
+    `node -e 'let d="";process.stdin.on("data",(c)=>d+=c);process.stdin.on("end",()=>{` +
+    `try{const j=JSON.parse(d||"{}");j.hook_event_name="${hookEventName}";j.source="gemini";process.stdout.write(JSON.stringify(j));}` +
+    `catch{process.stdout.write("{}");}});'`;
+  return `${TRANSFORM_COMMAND} | curl -s -X POST http://localhost:${port}/hook -H 'Content-Type: application/json' -d "$(cat)" > /dev/null 2>&1 &`;
+}
+
+function makeHooksConfig(port: number): Record<string, unknown[]> {
+  return {
+    BeforeAgent: [
+      {
+        hooks: [{ type: "command", command: makeHookCommand(port, "UserPromptSubmit") }],
+      },
+    ],
+    BeforeTool: [
+      {
+        matcher: ".*",
+        hooks: [{ type: "command", command: makeHookCommand(port, "PreToolUse") }],
+      },
+    ],
+    SessionStart: [
+      {
+        hooks: [{ type: "command", command: makeHookCommand(port, "SessionStart") }],
+      },
+    ],
+    SessionEnd: [
+      {
+        hooks: [{ type: "command", command: makeHookCommand(port, "SessionEnd") }],
+      },
+    ],
+    AfterAgent: [
+      {
+        hooks: [{ type: "command", command: makeHookCommand(port, "Stop") }],
+      },
+    ],
+  };
+}
+
+async function readGeminiSettings(
+  settingsPath: string,
+): Promise<z.infer<typeof GeminiSettingsSchema> | null> {
+  try {
+    const content = await readFile(settingsPath, "utf-8");
+    const raw = JSON.parse(content) as unknown;
+    const parsed = GeminiSettingsSchema.safeParse(raw);
+    if (!parsed.success) return null;
+    return parsed.data as z.infer<typeof GeminiSettingsSchema>;
+  } catch {
+    return null;
+  }
+}
+
+export async function setupGemini(port: number = DEFAULT_PORT): Promise<void> {
+  await mkdir(GEMINI_DIR, { recursive: true });
+
+  const settings = (await readGeminiSettings(GEMINI_SETTINGS_PATH)) ?? {};
+  const hooksConfig = makeHooksConfig(port);
+
+  settings.hooks = {
+    ...settings.hooks,
+    ...hooksConfig,
+  };
+
+  await writeFile(GEMINI_SETTINGS_PATH, JSON.stringify(settings, null, 2));
+
+  p.log.success("Gemini CLI hooks configured.");
+  p.log.info(`Path: ${pc.dim(GEMINI_SETTINGS_PATH)}`);
+  p.log.info(`Port: ${pc.dim(String(port))}`);
+}
+
+export async function isGeminiConfigured(): Promise<boolean> {
+  const settings = await readGeminiSettings(GEMINI_SETTINGS_PATH);
+  if (!settings || !settings.hooks) return false;
+
+  const keys = Object.keys(makeHooksConfig(DEFAULT_PORT));
+  return keys.some((hookName) => hookName in settings.hooks!);
+}
+
+export async function removeGemini(): Promise<void> {
+  const settings = await readGeminiSettings(GEMINI_SETTINGS_PATH);
+
+  if (!settings) {
+    p.log.info("No Gemini settings.json found, nothing to remove.");
+    return;
+  }
+
+  if (!settings.hooks) {
+    p.log.info("No Gemini hooks found in settings.json.");
+    return;
+  }
+
+  for (const hookName of Object.keys(makeHooksConfig(DEFAULT_PORT))) {
+    delete settings.hooks[hookName];
+  }
+
+  if (Object.keys(settings.hooks).length === 0) {
+    delete settings.hooks;
+  }
+
+  await writeFile(GEMINI_SETTINGS_PATH, JSON.stringify(settings, null, 2));
+  p.log.success("Gemini CLI hooks removed.");
+  p.log.info(`Path: ${pc.dim(GEMINI_SETTINGS_PATH)}`);
+}

--- a/packages/server/src/setup/index.ts
+++ b/packages/server/src/setup/index.ts
@@ -1,137 +1,105 @@
-import { emitKeypressEvents } from "node:readline";
+import * as p from "@clack/prompts";
+import pc from "picocolors";
 
-import { UI } from "@/lib/ui";
-
-type AgentType = "claude" | "opencode";
-
-type SetupStatus = {
-  claude: boolean;
-  opencode: boolean;
-};
 import { isClaudeConfigured, removeClaude, setupClaude } from "./claude";
+import { isClineConfigured, removeCline, setupCline } from "./cline";
+import { isCursorConfigured, removeCursor, setupCursor } from "./cursor";
+import { isGeminiConfigured, removeGemini, setupGemini } from "./gemini";
 import { isOpenCodeConfigured, removeOpenCode, setupOpenCode } from "./opencode";
 
-const AGENT_OPTIONS: { id: AgentType; label: string }[] = [
-  { id: "claude", label: "Claude Code (~/.claude/settings.json hooks)" },
-  { id: "opencode", label: "OpenCode (~/.config/opencode/plugin/)" },
+export type AgentType = "claude" | "opencode" | "gemini" | "cursor" | "cline";
+
+type SetupStatus = Record<AgentType, boolean>;
+
+const AGENT_OPTIONS: { id: AgentType; label: string; description: string }[] = [
+  { id: "claude", label: "Claude Code", description: "~/.claude/settings.json hooks" },
+  { id: "opencode", label: "OpenCode", description: "~/.config/opencode/plugin/" },
+  { id: "gemini", label: "Gemini CLI", description: "~/.gemini/settings.json hooks" },
+  { id: "cursor", label: "Cursor", description: "~/.cursor/hooks.json" },
+  { id: "cline", label: "Cline", description: "~/Documents/Cline/Rules/Hooks/ scripts" },
 ];
 
 async function selectAgents(prompt: string, defaultSelected: AgentType[]): Promise<AgentType[]> {
-  if (!process.stdin.isTTY) {
-    UI.println(UI.Style.TEXT_DIM + "Non-interactive shell detected." + UI.Style.TEXT_NORMAL);
-    return [];
+  const result = await p.multiselect({
+    message: prompt,
+    options: AGENT_OPTIONS.map((option) => ({
+      value: option.id,
+      label: option.label,
+      hint: option.description,
+    })),
+    initialValues: defaultSelected,
+    required: true,
+  });
+
+  if (p.isCancel(result)) {
+    p.cancel("Cancelled.");
+    process.exit(0);
   }
 
-  let cursor = 0;
-  const selected = new Set<AgentType>(defaultSelected);
-
-  const render = () => {
-    process.stderr.write("\x1b[2J\x1b[H");
-    UI.println(prompt);
-    UI.empty();
-
-    for (let i = 0; i < AGENT_OPTIONS.length; i++) {
-      const opt = AGENT_OPTIONS[i];
-      const isSelected = selected.has(opt.id);
-      const prefix = i === cursor ? UI.Style.TEXT_HIGHLIGHT_BOLD + ">" + UI.Style.TEXT_NORMAL : " ";
-      const checkbox = isSelected ? "[x]" : "[ ]";
-      UI.println(`${prefix} ${checkbox} ${opt.label}`);
-    }
-
-    UI.empty();
-    UI.println(
-      UI.Style.TEXT_DIM +
-        "Use ↑/↓ to move, space to toggle, enter to confirm" +
-        UI.Style.TEXT_NORMAL,
-    );
-  };
-
-  emitKeypressEvents(process.stdin);
-  const previousRawMode = process.stdin.isRaw ?? false;
-  process.stdin.setRawMode(true);
-  process.stdin.resume();
-
-  render();
-
-  return new Promise((resolve, reject) => {
-    const onKeypress = (_str: string, key: { name?: string; ctrl?: boolean }) => {
-      if (key.ctrl && key.name === "c") {
-        cleanup();
-        reject(new UI.CancelledError(undefined));
-        return;
-      }
-
-      if (key.name === "up") {
-        cursor = (cursor - 1 + AGENT_OPTIONS.length) % AGENT_OPTIONS.length;
-        render();
-        return;
-      }
-
-      if (key.name === "down") {
-        cursor = (cursor + 1) % AGENT_OPTIONS.length;
-        render();
-        return;
-      }
-
-      if (key.name === "space") {
-        const id = AGENT_OPTIONS[cursor].id;
-        if (selected.has(id)) selected.delete(id);
-        else selected.add(id);
-        render();
-        return;
-      }
-
-      if (key.name === "return") {
-        const result = Array.from(selected);
-        if (result.length === 0) {
-          render();
-          UI.empty();
-          UI.println(
-            UI.Style.TEXT_WARNING_BOLD + "Select at least one agent." + UI.Style.TEXT_NORMAL,
-          );
-          return;
-        }
-        cleanup();
-        resolve(result);
-      }
-    };
-
-    const cleanup = () => {
-      process.stdin.off("keypress", onKeypress);
-      process.stdin.setRawMode(previousRawMode);
-      process.stdin.pause();
-      process.stderr.write("\x1b[2J\x1b[H");
-    };
-
-    process.stdin.on("keypress", onKeypress);
-  });
+  return result as AgentType[];
 }
 
 export async function getSetupStatus(): Promise<SetupStatus> {
-  const [claude, opencode] = await Promise.all([isClaudeConfigured(), isOpenCodeConfigured()]);
-  return { claude, opencode };
+  const [claude, opencode, gemini, cursor, cline] = await Promise.all([
+    isClaudeConfigured(),
+    isOpenCodeConfigured(),
+    isGeminiConfigured(),
+    isCursorConfigured(),
+    isClineConfigured(),
+  ]);
+
+  return { claude, opencode, gemini, cursor, cline };
 }
 
 export async function setupAgent(agent: AgentType, port: number): Promise<void> {
-  if (agent === "claude") {
-    await setupClaude(port);
-    return;
+  switch (agent) {
+    case "claude":
+      await setupClaude(port);
+      break;
+    case "opencode":
+      await setupOpenCode(port);
+      break;
+    case "gemini":
+      await setupGemini(port);
+      break;
+    case "cursor":
+      await setupCursor(port);
+      break;
+    case "cline":
+      await setupCline(port);
+      break;
   }
-  await setupOpenCode(port);
 }
 
 export async function removeAgent(agent: AgentType): Promise<void> {
-  if (agent === "claude") {
-    await removeClaude();
-    return;
+  switch (agent) {
+    case "claude":
+      await removeClaude();
+      break;
+    case "opencode":
+      await removeOpenCode();
+      break;
+    case "gemini":
+      await removeGemini();
+      break;
+    case "cursor":
+      await removeCursor();
+      break;
+    case "cline":
+      await removeCline();
+      break;
   }
-  await removeOpenCode();
 }
 
 export async function interactiveSetup(port: number): Promise<void> {
+  if (!process.stdin.isTTY) {
+    p.log.warn(`Non-interactive shell detected. ${pc.dim("Use --setup <agent> or --setup all")}`);
+    return;
+  }
+
   const agents = await selectAgents(
-    "? Select AI coding agent(s) to configure:",
-    AGENT_OPTIONS.map((o) => o.id),
+    "Select AI coding agent(s) to configure:",
+    AGENT_OPTIONS.map((option) => option.id),
   );
 
   for (const agent of agents) {
@@ -141,20 +109,21 @@ export async function interactiveSetup(port: number): Promise<void> {
 
 export async function interactiveRemove(): Promise<void> {
   const status = await getSetupStatus();
-  const defaultSelected = AGENT_OPTIONS.filter((o) => status[o.id]).map((o) => o.id);
+  const defaultSelected = AGENT_OPTIONS.filter((option) => status[option.id]).map(
+    (option) => option.id,
+  );
 
   if (defaultSelected.length === 0) {
-    UI.println(UI.Style.TEXT_DIM + "No agents are configured." + UI.Style.TEXT_NORMAL);
+    p.log.info("No agents are configured.");
     return;
   }
 
   if (!process.stdin.isTTY) {
-    UI.println(UI.Style.TEXT_DIM + "Non-interactive shell detected." + UI.Style.TEXT_NORMAL);
-    UI.println("Run with '--remove claude', '--remove opencode', or '--remove all'.");
+    p.log.warn(`Non-interactive shell detected. ${pc.dim("Use --remove <agent> or --remove all")}`);
     return;
   }
 
-  const agents = await selectAgents("? Select AI coding agent(s) to remove:", defaultSelected);
+  const agents = await selectAgents("Select AI coding agent(s) to remove:", defaultSelected);
 
   for (const agent of agents) {
     await removeAgent(agent);

--- a/packages/server/src/setup/index.ts
+++ b/packages/server/src/setup/index.ts
@@ -91,10 +91,10 @@ export async function removeAgent(agent: AgentType): Promise<void> {
   }
 }
 
-export async function interactiveSetup(port: number): Promise<void> {
+export async function interactiveSetup(port: number): Promise<boolean> {
   if (!process.stdin.isTTY) {
     p.log.warn(`Non-interactive shell detected. ${pc.dim("Use --setup <agent> or --setup all")}`);
-    return;
+    return false;
   }
 
   const agents = await selectAgents(
@@ -105,9 +105,11 @@ export async function interactiveSetup(port: number): Promise<void> {
   for (const agent of agents) {
     await setupAgent(agent, port);
   }
+
+  return true;
 }
 
-export async function interactiveRemove(): Promise<void> {
+export async function interactiveRemove(): Promise<boolean> {
   const status = await getSetupStatus();
   const defaultSelected = AGENT_OPTIONS.filter((option) => status[option.id]).map(
     (option) => option.id,
@@ -115,12 +117,12 @@ export async function interactiveRemove(): Promise<void> {
 
   if (defaultSelected.length === 0) {
     p.log.info("No agents are configured.");
-    return;
+    return false;
   }
 
   if (!process.stdin.isTTY) {
     p.log.warn(`Non-interactive shell detected. ${pc.dim("Use --remove <agent> or --remove all")}`);
-    return;
+    return false;
   }
 
   const agents = await selectAgents("Select AI coding agent(s) to remove:", defaultSelected);
@@ -128,4 +130,6 @@ export async function interactiveRemove(): Promise<void> {
   for (const agent of agents) {
     await removeAgent(agent);
   }
+
+  return true;
 }

--- a/packages/server/src/setup/opencode.ts
+++ b/packages/server/src/setup/opencode.ts
@@ -2,7 +2,8 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
-import { UI } from "@/lib/ui";
+import * as p from "@clack/prompts";
+import pc from "picocolors";
 
 const CONFIG_DIR = join(homedir(), ".config", "opencode");
 const CONFIG_PATH = join(CONFIG_DIR, "opencode.json");
@@ -49,16 +50,13 @@ export async function setupOpenCode(port: number): Promise<void> {
 
   await writeConfig(config);
 
-  UI.println(UI.Style.TEXT_SUCCESS_BOLD + "OpenCode plugin configured." + UI.Style.TEXT_NORMAL);
-  UI.println(UI.Style.TEXT_DIM + `Config: ${CONFIG_PATH}` + UI.Style.TEXT_NORMAL);
-  UI.println(UI.Style.TEXT_DIM + `Plugin: ${PLUGIN_NAME}` + UI.Style.TEXT_NORMAL);
-  UI.println(UI.Style.TEXT_DIM + `Port: ${port}` + UI.Style.TEXT_NORMAL);
-  UI.println(
-    UI.Style.TEXT_DIM +
-      "Note: Set DISTRACTED_PORT environment variable if using a different port" +
-      UI.Style.TEXT_NORMAL,
+  p.log.success("OpenCode plugin configured.");
+  p.log.info(`Config: ${pc.dim(CONFIG_PATH)}`);
+  p.log.info(`Plugin: ${pc.dim(PLUGIN_NAME)}`);
+  p.log.info(`Port: ${pc.dim(String(port))}`);
+  p.log.info(
+    `Note: ${pc.dim("Set DISTRACTED_PORT environment variable if using a different port")}`,
   );
-  UI.empty();
 }
 
 export async function isOpenCodeConfigured(): Promise<boolean> {
@@ -73,22 +71,19 @@ export async function isOpenCodeConfigured(): Promise<boolean> {
 export async function removeOpenCode(): Promise<void> {
   const configured = await isOpenCodeConfigured();
   if (!configured) {
-    UI.println(
-      UI.Style.TEXT_DIM + "No OpenCode plugin found, nothing to remove." + UI.Style.TEXT_NORMAL,
-    );
+    p.log.info("No OpenCode plugin found, nothing to remove.");
     return;
   }
 
   const config = await readConfig();
   if (Array.isArray(config.plugin)) {
-    config.plugin = config.plugin.filter((p) => p !== PLUGIN_NAME);
+    config.plugin = config.plugin.filter((plugin) => plugin !== PLUGIN_NAME);
     if (config.plugin.length === 0) {
       delete config.plugin;
     }
   }
 
   await writeConfig(config);
-  UI.println(UI.Style.TEXT_SUCCESS_BOLD + "OpenCode plugin removed." + UI.Style.TEXT_NORMAL);
-  UI.println(UI.Style.TEXT_DIM + `Config: ${CONFIG_PATH}` + UI.Style.TEXT_NORMAL);
-  UI.empty();
+  p.log.success("OpenCode plugin removed.");
+  p.log.info(`Config: ${pc.dim(CONFIG_PATH)}`);
 }

--- a/packages/server/src/state.ts
+++ b/packages/server/src/state.ts
@@ -1,6 +1,8 @@
+import * as p from "@clack/prompts";
+import pc from "picocolors";
+
 import type { HookPayload, ServerMessage, Session } from "./types";
 import { SESSION_TIMEOUT_MS, USER_INPUT_TOOLS } from "./types";
-import { UI } from "@/lib/ui";
 
 type StateChangeCallback = (message: ServerMessage) => void;
 type StateMessage = Extract<ServerMessage, { type: "state" }>;
@@ -32,8 +34,11 @@ class SessionState {
 
   private getStateMessage(): StateMessage {
     const sessions = Array.from(this.sessions.values());
-    const working = sessions.filter((s) => s.status === "working").length;
-    const waitingForInput = sessions.filter((s) => s.status === "waiting_for_input").length;
+    const working = sessions.filter((session) => session.status === "working").length;
+    const waitingForInput = sessions.filter(
+      (session) => session.status === "waiting_for_input",
+    ).length;
+
     return {
       type: "state",
       blocked: working === 0,
@@ -52,6 +57,7 @@ class SessionState {
       waitingForInput: message.waitingForInput,
     };
     const prev = this.lastLoggedState;
+
     if (
       prev &&
       prev.blocked === next.blocked &&
@@ -61,9 +67,13 @@ class SessionState {
     ) {
       return;
     }
+
     this.lastLoggedState = next;
-    UI.println(
-      `Status: blocked=${next.blocked ? UI.Style.TEXT_DANGER : UI.Style.TEXT_SUCCESS}${next.blocked}${UI.Style.TEXT_NORMAL} sessions=${next.sessions} working=${next.working} waiting=${next.waitingForInput}`,
+    const blockedText = next.blocked
+      ? pc.red(String(next.blocked))
+      : pc.green(String(next.blocked));
+    p.log.info(
+      `Status: blocked=${blockedText} sessions=${next.sessions} working=${next.working} waiting=${next.waitingForInput}`,
     );
   }
 
@@ -105,7 +115,6 @@ class SessionState {
           session.status = "waiting_for_input";
           session.waitingForInputSince = new Date();
         } else if (session.status === "waiting_for_input") {
-          // If waiting for input, only reset after 500ms (ignore immediate tool calls like Edit)
           const elapsed = Date.now() - (session.waitingForInputSince?.getTime() ?? 0);
           if (elapsed > 500) {
             session.status = "working";
@@ -124,7 +133,6 @@ class SessionState {
         const session = this.sessions.get(session_id)!;
 
         if (session.status === "waiting_for_input") {
-          // Ignore immediate Stop after AskUserQuestion
           const elapsed = Date.now() - (session.waitingForInputSince?.getTime() ?? 0);
           if (elapsed > 500) {
             session.status = "idle";
@@ -146,21 +154,20 @@ class SessionState {
       beforeStatus !== afterStatus
     ) {
       const toolSuffix = payload.tool_name ? ` tool=${payload.tool_name}` : "";
-      UI.println(
-        UI.Style.TEXT_DIM +
-          `Hook: ${hook_event_name} session=${session_id}` +
-          toolSuffix +
-          ` status=${afterStatus ?? "none"}` +
-          UI.Style.TEXT_NORMAL,
+      p.log.step(
+        pc.dim(
+          `Hook: ${hook_event_name} session=${session_id}${toolSuffix} status=${afterStatus ?? "none"}`,
+        ),
       );
     }
-    this.logStatusIfChanged();
 
+    this.logStatusIfChanged();
     this.broadcast();
   }
 
   private ensureSession(sessionId: string, cwd?: string): void {
     if (this.sessions.has(sessionId)) return;
+
     this.sessions.set(sessionId, {
       id: sessionId,
       status: "idle",
@@ -176,16 +183,19 @@ class SessionState {
     for (const [id, session] of this.sessions) {
       if (now - session.lastActivity.getTime() > SESSION_TIMEOUT_MS) {
         this.sessions.delete(id);
-        removed++;
+        removed += 1;
       }
     }
 
-    if (removed > 0) this.broadcast();
+    if (removed > 0) {
+      this.broadcast();
+      this.logStatusIfChanged();
+    }
   }
 
   getStatus(): { blocked: boolean; sessions: Session[] } {
     const sessions = Array.from(this.sessions.values());
-    const working = sessions.filter((s) => s.status === "working").length;
+    const working = sessions.filter((session) => session.status === "working").length;
     return { blocked: working === 0, sessions };
   }
 

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -5,7 +5,7 @@ export interface HookPayload {
   tool_input?: Record<string, unknown>;
   cwd?: string;
   transcript_path?: string;
-  source?: "claude" | "opencode";
+  source?: "claude" | "opencode" | "gemini" | "cursor" | "cline" | "pi";
 }
 
 export interface Session {
@@ -28,8 +28,7 @@ export type ServerMessage =
 
 export type ClientMessage = { type: "ping" } | { type: "subscribe" };
 
-// Tools that indicate Claude is waiting for user input.
 export const USER_INPUT_TOOLS = ["AskUserQuestion", "ask_user", "ask_human"];
 
 export const DEFAULT_PORT = 8765;
-export const SESSION_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+export const SESSION_TIMEOUT_MS = 5 * 60 * 1000;


### PR DESCRIPTION
This PR expands AI coding agent hook support from 2 to 5 agents and modernizes the CLI UI framework.

**New agent setup modules**
- Add `packages/server/src/setup/gemini.ts`—configures `~/.gemini/settings.json` hooks, transforms BeforeAgent/BeforeTool/SessionStart/SessionEnd/AfterAgent events via inline Node.js script to normalized names
- Add `packages/server/src/setup/cursor.ts`—configures `~/.cursor/hooks.json` with sessionStart/preToolUse (matcher: "*")/stop hooks, transforms event names inline before POST
- Add `packages/server/src/setup/cline.ts`—creates executable Node scripts in `~/Documents/Cline/Rules/Hooks/` for TaskStart/UserPromptSubmit/PreToolUse/TaskComplete, uses marker comment `// @distracted/server hook` for detection/removal, awaits `Promise.allSettled` for multi-event POST

**Setup orchestration and CLI**
- Update `packages/server/src/setup/index.ts`—add gemini/cursor/cline to AgentType and SetupStatus, replace raw readline keypress multi-select with `@clack/prompts.multiselect`, update getSetupStatus/setupAgent/removeAgent interactiveSetup/interactiveRemove for all 5 agents
- Rewrite `packages/server/src/bin.ts`—remove `cac` dependency, implement manual `process.argv` parsing for `--setup`/`--remove`/`--status`/`--port`/`--help`, add clack intro/outro/confirm/log flow, support comma-separated agent lists

**Types and server**
- Update `packages/server/src/types.ts`—extend `HookPayload.source` union to include `"claude" | "opencode" | "gemini" | "cursor" | "cline" | "pi"`
- Update `packages/server/src/server.ts`—validate source against expanded list, replace startServer banner with `p.note`/`p.log.info`, use picocolors for status output
- Update `packages/server/src/state.ts`—replace UI.Style.* and UI.println with `@clack/prompts` (`p.log.step` for hook events, `p.log.info` for status updates), use picocolors for colored output

**Existing setup and dependencies**
- Update `packages/server/src/setup/claude.ts` and `opencode.ts`—replace UI.println/UI.Style usage with `p.log.success`/`p.log.info` and picocolors dim
- Update `packages/server/package.json`—add `@clack/prompts` and `picocolors`, remove `cac`

<a href="https://capy.ai/project/480c2640-72a8-49b6-a462-8f9af418b4b1/pull/31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/480c2640-72a8-49b6-a462-8f9af418b4b1/task/3691ffa7-cfd9-4e41-904d-c7135fc1b821"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.3-codex-fast&task=DIS-15&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.3-codex-fast&task=DIS-15"><img alt="DIS-15 · 5.3-Codex-Fast" src="https://capy.ai/api/badge/task.svg?model=gpt-5.3-codex-fast&task=DIS-15"></picture></a>